### PR TITLE
Include Translation Helpers if defined

### DIFF
--- a/lib/boring_presenters/presenter.rb
+++ b/lib/boring_presenters/presenter.rb
@@ -3,6 +3,7 @@
 module Boring
   class Presenter #:nodoc:
     extend Forwardable
+    include ActionView::Helpers::TranslationHelper if defined? ActionView::Helpers::TranslationHelper
 
     class << self
       attr_accessor :__arguments


### PR DESCRIPTION
Since this is largely used as view code this (might successfully?) include the TranslationHelpers for use in Presenter code.